### PR TITLE
Feature raspicat_usb_audio_set_up

### DIFF
--- a/raspicat_usb_audio_set_up/CMakeLists.txt
+++ b/raspicat_usb_audio_set_up/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(raspicat_usb_audio_set_up)
+find_package(catkin REQUIRED)

--- a/raspicat_usb_audio_set_up/package.xml
+++ b/raspicat_usb_audio_set_up/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>raspicat_usb_audio_set_up</name>
+  <version>0.0.0</version>
+  <description>The raspicat_usb_audio_set_up package</description>
+
+  <maintainer email="beike315@icloud.com">Tatsuhiro Ikebe</maintainer>
+
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/raspicat_usb_audio_set_up/scripts/setup.sh
+++ b/raspicat_usb_audio_set_up/scripts/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+if [ ! ${EUID:-${UID}} = 0 ]; then
+	echo "You need to run this script as root." && exit 1
+fi
+
+echo "options snd slots=snd_usb_audio
+options snd_usb_audio index=0" >> /etc/modprobe.d/alsa-base.conf
+
+cat /proc/asound/modules
+
+echo "Please reboot to reflect the settings."


### PR DESCRIPTION
* raspiがusbオーディオをデフォルトで使用するようにするためのパッケージを追加