### PR TITLE
Feature docker run exec raspicat_navigation

### DIFF
--- a/raspicat_switch_control/scripts/SW0.sh
+++ b/raspicat_switch_control/scripts/SW0.sh
@@ -5,8 +5,8 @@
 # When the switch is on
 if [ $1 = "on" ]; then
   echo start_raspicat_navigation
-  roslaunch raspicat_waypoint_navigation raspicat_raspi_only_navigation.launch urg:=true mcl_init_pose_x:=0.0 mcl_init_pose_y:=0.0 mcl_init_pose_a:=0.0 waypoint_yaml_file:=$(rospack find raspicat_waypoint_navigation)/config/waypoint/waypoint_tsukuba.yaml move_base_map_file:=$(rospack find raspicat_waypoint_navigation)/config/maps/for_move_base/map_tsukuba.yaml mcl_map_file:=$(rospack find raspicat_waypoint_navigation)/config/maps/tsukuba/map_tsukuba.yaml lidar_ether:=true lidar_ip_address:=172.16.0.10 &
-  raspicat_navigation_pid=$!
+  docker rm -f raspicat-noetic
+  docker run --privileged --net=host -v /dev:/dev -e ROS_MASTER_URI=http://192.168.12.1:11311 -e ROS_HOSTNAME=192.168.12.1 -e PULSE_COOKIE=/tmp/pulse/cookie -e PULSE_SERVER=unix:/tmp/pulse/native -v /run/user/1000/pulse/native:/tmp/pulse/native -v ~/.config/pulse/cookie:/tmp/pulse/cookie:ro --name raspicat-noetic ubeike/raspicat-noetic:arm64v8 bash -c 'source ~/catkin_ws/devel/setup.bash;roslaunch raspicat_waypoint_navigation raspicat_raspi_only_navigation.launch urg:=true mcl:=emcl2 world_name:=tsukuba lidar_ether:=true lidar_ip_address:=172.16.0.10' &
   led_on 1
   sleep 3
 fi
@@ -17,10 +17,9 @@ fi
 # When the switch is off
 if [ $1 = "off" ]; then
   echo finish_raspicat_navigation
-  kill $raspicat_navigation_pid
+  docker exec raspicat-noetic pkill -9 rosmaster
   led_off 1
-  killall rosmaster
-  exit
   sleep 3
+  exit
 fi
 ########################

--- a/raspicat_switch_control/scripts/SW1.sh
+++ b/raspicat_switch_control/scripts/SW1.sh
@@ -5,7 +5,7 @@
 # When the switch is off
 if [ $1 = "off" ] || [ -n "$count" ]; then
   echo restart_waypoint_navigation
-  rosservice call --wait /way_nav_restart & 
+  docker exec raspicat-noetic bash -c "source /opt/ros/noetic/setup.bash;rosservice call --wait /way_nav_restart" & 
   led_off 2
   sleep 2
 fi
@@ -16,7 +16,9 @@ fi
 # When the switch is on
 if [ $1 = "on" ] && [ -z "$count" ]; then
   echo start_waypoint_navigation
-  rosservice call --wait /way_nav_start & 
+  docker exec raspicat-noetic bash -c "source /opt/ros/noetic/setup.bash;rostopic pub -1 /way_navigation_start std_msgs/Empty" &
+  sleep 5
+  docker exec raspicat-noetic bash -c "source /opt/ros/noetic/setup.bash;rosservice call --wait /way_nav_start" & 
   led_on 2
   count=0
   sleep 2


### PR DESCRIPTION
* dockerのコンテナ立ち上げ、docker execでナビゲーションのスタートが出来るようにした

logは`journalctl`や`docker logs -f`で確認可能